### PR TITLE
feat: expose a shared eager module

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,11 +8,6 @@
                         get: () => () => Promise.resolve({ v4: { mock: 'uuid'} }),
                     }
                 },
-                react: {
-                    '18.3.0': {
-                        get: () => () => Promise.resolve("mock react"),
-                    }
-                }
             };
             
             globalThis.sharedScope = sharedScope;
@@ -25,14 +20,9 @@
             await container.init(sharedScope);
             console.log("shared scope: ", JSON.stringify(sharedScope, null, 2));
             
-            console.log("doing container.get('./react')");
-            const react = (await container.get('./react'))();
-            console.log("exposed module ./react: ", react);
-            console.log("shared scope: ", JSON.stringify(sharedScope, null, 2));
-            
-            console.log("doing container.get('./index')");
-            const index = (await container.get('./index'))();
-            console.log("exposed module ./index", index);
+            console.log("doing container.get('./expose-shared-eager')");
+            const exposedSharedEager = (await container.get('./expose-shared-eager'))();
+            console.log("exposed module ./expose-shared-eager", exposedSharedEager);
         </script>
     </head>
     <body></body>

--- a/src/expose-shared-eager.js
+++ b/src/expose-shared-eager.js
@@ -1,0 +1,7 @@
+import ReactDOM from "react-dom";
+
+function doRandom() {
+    console.log(ReactDOM);
+}
+
+doRandom();

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -22,15 +22,18 @@ module.exports = {
       exposes: {
         './index': './src/index.js',
         './react': 'react',
+        './expose-shared-eager': './src/expose-shared-eager.js'
       },
       shared: {
-        react: {
-          eager: true,
-        },
+        react: {},
         'react-dom': {},
         uuid: {
           import: false,
         },
+        'exposed-shared-eager': {
+          import: './src/expose-shared-eager.js',
+          eager: true
+        }
       },
       /**
        * Additional stuff for webpack.


### PR DESCRIPTION
Shows the problem with marking a module as `exposed`, `shared` and `eager`.

- `expose-shared-eager.js` is marked as `exposed`, `shared` and `eager`
- `react-dom` is a `shared` dependency used in `expose-shared-eager.js`
    - `react-dom` is not marked as `eager`

When we call: 
```js
container.get('./expose-shared-eager')
```
we get the following error:

```sh
Uncaught Error: Shared module is not available for eager consumption: webpack/sharing/consume/default/react-dom/react-dom
```

Even the though the module `expose-shared-eager.js` is marked as `shared` and `eager` and `exposed`, it's shared dependencies are not automatically marked as `eager`
