### PR TITLE
feat: sharing local non-dependency module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,9 @@
         "semantic-release": "^21.0.6",
         "webpack": "^5.84.1",
         "webpack-cli": "^5.1.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     },
     "./remote": {
       "import": "./dist/webpack/remoteEntry.js"
+    },
+    "./something": {
+      "import": "./dist/webpack/something.js"
     }
   },
   "engines": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -6,7 +6,10 @@ import copy from 'rollup-plugin-copy';
 const outputDir = 'dist/rollup';
 
 export default {
-  input: './src/index.js',
+  input: {
+    'index': './src/index.js',
+    'something': './src/something.js'
+  },
   output: {
     dir: outputDir,
     format: 'es',
@@ -20,6 +23,7 @@ export default {
       exposes: {
         './index': './src/index.js',
         './react': 'react',
+        './something': './src/something.js'
       },
       shared: {
         react: {
@@ -29,6 +33,12 @@ export default {
         uuid: {
           import: false,
         },
+        // NOTE: rollup's federation is not allowing to do this. 
+        // I think its beacuse of the order in which the federation plugin does things.
+        // https://github.com/originjs/vite-plugin-federation/blob/main/packages/lib/src/index.ts#L56-L58
+        // 'module-federation-experiments/something': {
+        //   import: './src/something.js',
+        // },
       },
     }),
     copy({

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,6 +2,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import federation from '@originjs/vite-plugin-federation';
 import copy from 'rollup-plugin-copy';
+import pkgJson from './package.json' assert { type: "json" };
 
 const outputDir = 'dist/rollup';
 
@@ -38,6 +39,7 @@ export default {
         // https://github.com/originjs/vite-plugin-federation/blob/main/packages/lib/src/index.ts#L56-L58
         // 'module-federation-experiments/something': {
         //   import: './src/something.js',
+        //   version: pkgJson.version,
         // },
       },
     }),

--- a/src/something.js
+++ b/src/something.js
@@ -1,0 +1,7 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+export function doAnotherThing() {
+    console.log(React);
+    console.log(ReactDOM);
+}

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -1,6 +1,7 @@
 const path = require('path');
 const { ModuleFederationPlugin } = require('webpack').container;
 const CopyPlugin = require("copy-webpack-plugin");
+const pkgJson = require('./package.json');
 
 module.exports = {
   mode: 'development',
@@ -37,6 +38,7 @@ module.exports = {
         },
         'module-federation-experiments/something': {
           import: './src/something.js',
+          version: pkgJson.version,
         },
       },
       /**

--- a/webpack.config.cjs
+++ b/webpack.config.cjs
@@ -4,10 +4,13 @@ const CopyPlugin = require("copy-webpack-plugin");
 
 module.exports = {
   mode: 'development',
-  entry: './src/index.js',
+  entry: {
+    'index': path.resolve(__dirname, 'src/index.js'),
+    'something': path.resolve(__dirname, 'src/something.js')
+  },
   output: {
     path: path.resolve(__dirname, 'dist/webpack'),
-    filename: 'index.js',
+    filename: '[name].js',
     library: {
       type: 'module',
     },
@@ -22,6 +25,7 @@ module.exports = {
       exposes: {
         './index': './src/index.js',
         './react': 'react',
+        './something': './src/something.js'
       },
       shared: {
         react: {
@@ -30,6 +34,9 @@ module.exports = {
         'react-dom': {},
         uuid: {
           import: false,
+        },
+        'module-federation-experiments/something': {
+          import: './src/something.js',
         },
       },
       /**


### PR DESCRIPTION
- Shares a local module which is not a dependency through Module Federation's `shared` contract.
- Observations:
  - webpack seems to work fine
  - The version of the `shared` module is `0` when not explicitly specified.
- rollup has build issues